### PR TITLE
Add basic object writing to ODB over IPC hackweek project

### DIFF
--- a/object-file.c
+++ b/object-file.c
@@ -2490,10 +2490,10 @@ static int hash_format_check_report(struct fsck_options *opts UNUSED,
 	return 1;
 }
 
-static int index_mem(struct index_state *istate,
-		     struct object_id *oid, void *buf, size_t size,
-		     enum object_type type,
-		     const char *path, unsigned flags)
+int index_mem(struct index_state *istate,
+	      struct object_id *oid, void *buf, size_t size,
+	      enum object_type type,
+	      const char *path, unsigned flags)
 {
 	int ret = 0;
 	int re_allocated = 0;

--- a/object-file.c
+++ b/object-file.c
@@ -2631,6 +2631,10 @@ int index_fd(struct index_state *istate, struct object_id *oid,
 	     enum object_type type, const char *path, unsigned flags)
 {
 	int ret;
+	if (!odb_over_ipc__hash_object(the_repository, oid, fd, type, flags)) {
+		close(fd);
+		return 0;
+	}
 
 	/*
 	 * Call xsize_t() only when needed to avoid potentially unnecessary

--- a/object-file.h
+++ b/object-file.h
@@ -20,6 +20,7 @@ extern int fetch_if_missing;
 #define HASH_SILENT 8
 int index_fd(struct index_state *istate, struct object_id *oid, int fd, struct stat *st, enum object_type type, const char *path, unsigned flags);
 int index_path(struct index_state *istate, struct object_id *oid, const char *path, struct stat *st, unsigned flags);
+int index_mem(struct index_state *istate, struct object_id *oid, void *buf, size_t size, enum object_type type, const char *path, unsigned flags);
 
 /*
  * Create the directory containing the named path, using care to be

--- a/odb-over-ipc.h
+++ b/odb-over-ipc.h
@@ -68,6 +68,20 @@ struct odb_over_ipc__get_oid__response
 	enum object_type type;
 };
 
+struct odb_over_ipc__hash_object__request
+{
+	struct odb_over_ipc__key key;
+	enum object_type type;
+	unsigned flags;
+	size_t content_size;
+};
+
+struct odb_over_ipc__hash_object__response
+{
+	struct odb_over_ipc__key key;
+	struct object_id oid;
+};
+
 /*
  * Connect to an existing `git odb--daemon` process and ask it for
  * an object.  This is intended to be inserted into the client
@@ -81,6 +95,10 @@ struct repository;
 
 int odb_over_ipc__get_oid(struct repository *r, const struct object_id *oid,
 			  struct object_info *oi, unsigned flags);
+
+
+int odb_over_ipc__hash_object(struct repository *r, struct object_id *oid,
+			      int fd, enum object_type type, unsigned flags);
 
 /*
  * Explicitly shutdown IPC connection to the `git odb--daemon` process.


### PR DESCRIPTION
Implement a basic version of the hash-object command in the ODB daemon that will compute the hash of the provided object contents, and optionally write through to the ODB on the file system.